### PR TITLE
Oauth2client 2.0 compability

### DIFF
--- a/ferris3/oauth2.py
+++ b/ferris3/oauth2.py
@@ -4,6 +4,7 @@ import hashlib
 import endpoints
 import os
 from oauth2client.client import AccessTokenCredentials
+from oauth2client.service_account import ServiceAccountCredentials
 
 
 def get_endpoints_credentials():
@@ -48,22 +49,28 @@ def build_service_account_credentials(scope, user=None):
     Builds service account credentials using the configuration stored in :mod:`~ferris3.settings`
     and masquerading as the provided user.
     """
-    if not SignedJwtAssertionCredentials:
-        raise EnvironmentError("Service account can not be used because PyCrypto is not available. Please install PyCrypto.")
-
     config = _get_config()
 
-    if not isinstance(scope, (list, tuple)):
-        scope = [scope]
+    if hasattr(ServiceAccountCredentials, "from_json_keyfile_dict"):
+        # running oauth2client version 2.0
+        creds = ServiceAccountCredentials.from_json_keyfile_dict(config, scope)
+        if user is not None:
+            creds.create_delegated(user)
+    else:
+        if not SignedJwtAssertionCredentials:
+            raise EnvironmentError("Service account can not be used because PyCrypto is not available. Please install PyCrypto.")
 
-    key = _generate_storage_key(config['client_email'], scope, user)
-    storage = StorageByKeyName(ServiceAccountStorage, key, 'credentials')
+        if not isinstance(scope, (list, tuple)):
+            scope = [scope]
 
-    creds = SignedJwtAssertionCredentials(
-        service_account_name=config['client_email'],
-        private_key=config['private_key'],
-        scope=scope,
-        prn=user)
+        key = _generate_storage_key(config['client_email'], scope, user)
+        storage = StorageByKeyName(ServiceAccountStorage, key, 'credentials')
+
+        creds = SignedJwtAssertionCredentials(
+            service_account_name=config['client_email'],
+            private_key=config['private_key'],
+            scope=scope,
+            prn=user)
     creds.set_store(storage)
 
     return creds

--- a/ferris3/oauth2.py
+++ b/ferris3/oauth2.py
@@ -38,8 +38,10 @@ try:
 except ImportError:
     SignedJwtAssertionCredentials = None
 
-from oauth2client.appengine import StorageByKeyName, CredentialsNDBProperty
-
+try:
+    from oauth2client.contrib.appengine import StorageByKeyName, CredentialsNDBProperty
+except ImportError:
+    from oauth2client.appengine import StorageByKeyName, CredentialsNDBProperty
 
 def build_service_account_credentials(scope, user=None):
     """

--- a/ferris3/oauth2.py
+++ b/ferris3/oauth2.py
@@ -55,7 +55,7 @@ def build_service_account_credentials(scope, user=None):
         # running oauth2client version 2.0
         creds = ServiceAccountCredentials.from_json_keyfile_dict(config, scope)
         if user is not None:
-            creds.create_delegated(user)
+            creds = creds.create_delegated(user)
     else:
         if not SignedJwtAssertionCredentials:
             raise EnvironmentError("Service account can not be used because PyCrypto is not available. Please install PyCrypto.")
@@ -63,14 +63,14 @@ def build_service_account_credentials(scope, user=None):
         if not isinstance(scope, (list, tuple)):
             scope = [scope]
 
-        key = _generate_storage_key(config['client_email'], scope, user)
-        storage = StorageByKeyName(ServiceAccountStorage, key, 'credentials')
-
         creds = SignedJwtAssertionCredentials(
             service_account_name=config['client_email'],
             private_key=config['private_key'],
             scope=scope,
             prn=user)
+
+    key = _generate_storage_key(config['client_email'], scope, user)
+    storage = StorageByKeyName(ServiceAccountStorage, key, 'credentials')
     creds.set_store(storage)
 
     return creds


### PR DESCRIPTION
As mentioned in #27 ferris3 is not compatible with oauth2client version 2.0 which is installed by default by google-python-api-client. This pull request fixes this issue without breaking compatibility to version 1.5.